### PR TITLE
Changed Linux .desktop Category

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "buildResources": "resources"
     },
     "linux": {
-      "category": "Utils",
+      "category": "Utility",
       "target": [
         {
           "target": "AppImage",


### PR DESCRIPTION
Arch complains about invalid category 'Utils' - prefers 'Utility'